### PR TITLE
Update Package.swift to support Nuke version 11 ..< 13

### DIFF
--- a/Nuke_AVIF_PluginTests/AVIFImageDecoderTests.swift
+++ b/Nuke_AVIF_PluginTests/AVIFImageDecoderTests.swift
@@ -49,7 +49,8 @@ class AVIFImageDecoderTests: XCTestCase {
         let exception = XCTestExpectation(description: "decode avif image")
         Nuke.DataLoader.sharedUrlCache.removeAllCachedResponses()
         AVIFImageDecoder.enable()
-        Nuke.ImagePipeline.shared.loadImage(with: self.avifImageURL, progress: nil) { (result) in
+        let request = ImageRequest(url: self.avifImageURL)
+        Nuke.ImagePipeline.shared.loadImage(with: request, progress: nil) { (result) in
             switch result {
             case .success(let imageResponse):
                 XCTAssertNotNil(imageResponse.image)
@@ -59,7 +60,7 @@ class AVIFImageDecoderTests: XCTestCase {
             exception.fulfill()
         }
 
-        self.wait(for: [exception], timeout: 1)
+        self.wait(for: [exception], timeout: 2)
     }
 
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "0c52c84849acb64c0549eb830befcc5b1c522f7597beb1563daae20c0285de0d",
   "pins" : [
     {
       "identity" : "libaom-xcode",
@@ -32,10 +33,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/Nuke.git",
       "state" : {
-        "revision" : "93c8dc78fbc0aa3538a0db460eb389d4180af242",
-        "version" : "11.3.1"
+        "revision" : "0ead44350d2737db384908569c012fe67c421e4d",
+        "version" : "12.8.0"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.10
 import PackageDescription
 
 let package = Package(
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "NukeAVIFPlugin", targets: ["NukeAVIFPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/kean/Nuke.git", from: "11.0.0"),
+        .package(url: "https://github.com/kean/Nuke.git", "11.0.0"..<"13.0.0"),
         .package(url: "https://github.com/SDWebImage/libavif-Xcode.git", exact: "0.10.1")
     ],
     targets: [


### PR DESCRIPTION
Update Package.swift with the following changes:
- swift-tools-version to `5.10` (was 5.6) (ref: [Swift Package Manager changelog](https://github.com/swiftlang/swift-package-manager/blob/main/CHANGELOG.md#swift-510))
- Nuke package version to `11 ..< 13` (was from 11.0.0)

Update the test results on the local side.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/49ca6ff3-e5cd-4b65-a6af-8ae0b538b9e9">
